### PR TITLE
Bug Fix String.Casing.{downcase, upcase } #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ Defining Custom Sigils
 ```elixir
 defmodule MySigils do
   #returns the downcasing string if option l is given then returns the list of downcase letters
-  def sigil_l(string,[]), do: String.Casing.downcase(string)
-  def sigil_l(string,[?l]), do: String.Casing.downcase(string) |> String.graphemes
+  def sigil_l(string,[]), do: String.downcase(string)
+  def sigil_l(string,[?l]), do: String.downcase(string) |> String.graphemes
   
   #returns the upcasing string if option l is given then returns the list of downcase letters
-  def sigil_u(string,[]), do: String.Casing.upcase(string)
-  def sigil_u(string,[?l]), do: String.Casing.upcase(string) |> String.graphemes
+  def sigil_u(string,[]), do: String.upcase(string)
+  def sigil_u(string,[?l]), do: String.upcase(string) |> String.graphemes
 end
 ```
 #### usage


### PR DESCRIPTION
The function String.Casing.upcase and String.Casing.downcase are updated to String.upcase and String.downcase respectively.